### PR TITLE
Update rtos and network-stack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
         "xmake.additionalConfigArguments": "--sdk=/cheriot-tools/"
       }
     }
-  }
+  },
+  "mounts" : [
+    "source=/media/phil/SONATA,target=/mnt/SONATA,type=bind"
+  ]
 }
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,6 @@
         "xmake.additionalConfigArguments": "--sdk=/cheriot-tools/"
       }
     }
-  },
-  "mounts" : [
-    "source=/media/phil/SONATA,target=/mnt/SONATA,type=bind"
-  ]
+  }
 }
 

--- a/configuration_broker/common/config_consumer/config_consumer.cc
+++ b/configuration_broker/common/config_consumer/config_consumer.cc
@@ -51,7 +51,7 @@ namespace ConfigConsumer
 		// events as if each item has been updated.
 		for (auto i = 0; i < numOfItems; i++)
 		{
-			events[i] = {nullptr, EventWaiterFutex, 1};
+			events[i] = {nullptr, 1};
 		}
 
 		// Loop waiting for config changes.  The flow in here
@@ -94,7 +94,7 @@ namespace ConfigConsumer
 					// Make a fast claim on the data now, the handler
 					// can decide if it wants to make a full claim
 					Timeout t{5000};
-					int     claimed = heap_claim_fast(&t, item.data, nullptr);
+					int     claimed = heap_claim_ephemeral(&t, item.data, nullptr);
 					if (claimed != 0)
 					{
 						Debug::log(
@@ -123,7 +123,6 @@ namespace ConfigConsumer
 			for (auto i = 0; i < numOfItems; i++)
 			{
 				events[i] = {configItems[i].versionFutex,
-				             EventWaiterFutex,
 				             configItems[i].version};
 			}
 


### PR DESCRIPTION
Updates rtos and network-stack submodules, and fixes issues arrising in coinfiguration-broker

Note for reviewers:
the compartmentalisation demo build now fails with 
```
error: ld.lld: error: build/cheriot/cheriot/release/insecure_js.compartment:(function set_secret(): .text+0x13ac): relocation against symbol  which is not defined
``` 