### PR TITLE
Configuration-broker: Make signed message support optional

### DIFF
--- a/configuration_broker/README.md
+++ b/configuration_broker/README.md
@@ -54,6 +54,7 @@ Providing a generic broker and expressing the trust model via its interfaces mak
 - [Sonata](#sonata)
   - [Threads](#threads-1)
   - [Build Instructions (Dev container)](#build-instructions-dev-container-1)
+  - [Signed Message Support](#signed-message-support)
 
 
 # Overview
@@ -630,6 +631,15 @@ sonata-config/Config/MySonata-0/rbg_LED
 {"led0":{"red":0,"green":40,"blue":40},"led1":{"red":50,"green":0,"blue":0}}
 ```
 
+## Signed Message Support
+The sonata demo can be compiled to support signed MQTT messages
+
+```
+xmake config --IPv6=n --system-id=MySonata --MQTT_Signed=true --sdk=/cheriot-tools/ -P .
+```
+In this case all configuration messages must carry a valid signature, and all status messages wil be signed.
+
+_Note: Signing support is being activelydeveloped as part of the DSbD TAP program. Currently it depend on keys being compiled into the build from provider/keys, and we are still working to provide an extanal signing toolm hopefully as part of [CyberChef](https://gchq.github.io/CyberChef/)_
 
 [^init] Yet. See https://github.com/CHERIoT-Platform/cheriot-rtos/issues/275
 

--- a/configuration_broker/README.md
+++ b/configuration_broker/README.md
@@ -639,7 +639,7 @@ xmake config --IPv6=n --system-id=MySonata --MQTT_Signed=true --sdk=/cheriot-too
 ```
 In this case all configuration messages must carry a valid signature, and all status messages wil be signed.
 
-_Note: Signing support is being activelydeveloped as part of the DSbD TAP program. Currently it depend on keys being compiled into the build from provider/keys, and we are still working to provide an extanal signing toolm hopefully as part of [CyberChef](https://gchq.github.io/CyberChef/)_
+_Note: Signing support is being actively developed as part of the DSbD TAP program. Currently it depend on keys being compiled into the build from `provider/keys`, and we are still working to provide an external signing tool, hopefully as part of [CyberChef](https://gchq.github.io/CyberChef/)_
 
 [^init] Yet. See https://github.com/CHERIoT-Platform/cheriot-rtos/issues/275
 

--- a/configuration_broker/README.md
+++ b/configuration_broker/README.md
@@ -641,5 +641,5 @@ In this case all configuration messages must carry a valid signature, and all st
 
 _Note: Signing support is being actively developed as part of the DSbD TAP program. Currently it depend on keys being compiled into the build from `provider/keys`, and we are still working to provide an external signing tool, hopefully as part of [CyberChef](https://gchq.github.io/CyberChef/)_
 
-[^init] Yet. See https://github.com/CHERIoT-Platform/cheriot-rtos/issues/275
+[^init]: Yet. See https://github.com/CHERIoT-Platform/cheriot-rtos/issues/275
 

--- a/configuration_broker/sonata/provider/signature.cc
+++ b/configuration_broker/sonata/provider/signature.cc
@@ -14,12 +14,12 @@ using Error = ConditionalDebug<true, "Crypto">;
 
 using CHERI::Capability;
 
-#include "signature.h"
 #include "../../../third_party/crypto/crypto.h"
+#include "signature.h"
 
 // Keys used for signatures - for now compiled in but
 // should be runtime supplied, such as read from the SD
-// card. 
+// card.
 #include "./keys/config_pub_key.h"
 #include "./keys/status_pri_key.h"
 #include "./keys/status_pub_key.h"
@@ -27,82 +27,108 @@ using CHERI::Capability;
 // Size of the header in signed messages
 #define SIGN_HEADER_BYTES hydro_sign_CONTEXTBYTES + hydro_sign_BYTES
 
-namespace SIGNATURE {
-
-/** 
- * Verify a signature in a payload.
- *
- * Packed as Context[8] + Signature[64] + Message
- */
-Message verify_signature(const void *payload, size_t payloadLength)
+namespace SIGNATURE
 {
-	size_t messageOffset = SIGN_HEADER_BYTES;
-	if (payloadLength <= messageOffset)
+
+	constexpr bool SigningEnabled = MQTT_Signed;
+
+	/**
+	 * Verify a signature in a payload.
+	 *
+	 * Packed as Context[8] + Signature[64] + Message
+	 */
+	Message verify_signature(const void *payload, size_t payloadLength)
 	{
-		Error::log("Message too short to verify");
-		return {nullptr, 0};
+		if (!SigningEnabled)
+		{
+			Capability roMessage{(void *)payload};
+			roMessage.permissions() &= {CHERI::Permission::Load};
+			roMessage.bounds() = payloadLength;
+			return {roMessage, payloadLength};
+		}
+
+		size_t messageOffset = SIGN_HEADER_BYTES;
+		if (payloadLength <= messageOffset)
+		{
+			Error::log("Message too short to verify");
+			return {nullptr, 0};
+		}
+		const char    *context = (char *)payload;
+		const uint8_t *signature =
+		  (uint8_t *)(context + hydro_sign_CONTEXTBYTES);
+		void  *message       = (void *)(context + messageOffset);
+		size_t messageLength = payloadLength - messageOffset;
+
+		//
+		// Stuff to look up key from context goes here
+		//
+		uint8_t *key = config_pub_key;
+
+		if (crypto_verify_signature(
+		      signature, message, messageLength, context, key) == 0)
+		{
+			Debug::log("Signature Verified");
+			Capability roMessage{message};
+			roMessage.permissions() &= {CHERI::Permission::Load};
+			roMessage.bounds() = messageLength;
+			return {roMessage, messageLength};
+		}
+		else
+		{
+			Error::log("Signature validation failed");
+			return {nullptr, 0};
+		}
 	}
-	const char *context = (char *)payload;
-	const uint8_t *signature = (uint8_t *)(context + hydro_sign_CONTEXTBYTES);
-	void *message = (void *)(context + messageOffset);
-	size_t messageLength = payloadLength - messageOffset;
-	
-	//
-	// Stuff to look up key from context goes here
-	//
-	uint8_t *key = config_pub_key;
-	
-	if (crypto_verify_signature(signature, message, messageLength, context, key) == 0)
+
+	/**
+	 * Create a signed message.
+	 *
+	 * Packed as Context[8] + Signature[64] + Message
+	 */
+	Message sign(AllocatorCapability allocator,
+	             const char         *context,
+	             const char         *message,
+	             size_t              messageLength)
 	{
-		Debug::log("Signature Verified");
-		Capability roMessage {message};
-		roMessage.permissions() &= {CHERI::Permission::Load};
-		roMessage.bounds() = messageLength;
-		return {roMessage, messageLength};  
+		if (!SigningEnabled)
+		{
+			Capability<void> cap = {(void *)message};
+			cap.permissions() &= {CHERI::Permission::Load};
+			cap.bounds() = messageLength;
+			return {cap, messageLength};
+		}
+
+		Timeout t{100};
+		size_t  s_size         = SIGN_HEADER_BYTES + messageLength;
+		void   *signed_message = heap_allocate(&t, allocator, s_size);
+		if (!Capability{signed_message}.is_valid())
+		{
+			Debug::log("Failed to allocate {} of heap for signed message",
+			           s_size);
+			return {nullptr, 0};
+		}
+
+		char    *s_context   = (char *)signed_message;
+		uint8_t *s_signature = (uint8_t *)s_context + hydro_sign_CONTEXTBYTES;
+		char    *s_message   = (char *)s_signature + hydro_sign_BYTES;
+
+		strncpy(s_context, context, hydro_sign_CONTEXTBYTES);
+		strncpy(s_message, message, messageLength);
+
+		// Stuff to look up key from context goes here
+		//
+		uint8_t *key = status_pri_key;
+
+		crypto_sign(
+		  s_signature, message, messageLength, context, status_pri_key);
+		Debug::log("Signature generated");
+
+		// Create a read only capabilty that is bound to the size of the message
+		Capability<void> s_cap = {signed_message};
+		s_cap.permissions() &= {CHERI::Permission::Load};
+		s_cap.bounds() = s_size;
+
+		return {s_cap, s_size};
 	}
-	else {
-		Error::log("Signature validation failed");
-		return {nullptr, 0};
-	}
-}
 
-/**
- * Create a signed message.
- *
- * Packed as Context[8] + Signature[64] + Message
- */
-Message sign(AllocatorCapability allocator, const char* context,
-               const char *message, size_t messageLength) {
-
-	Timeout t{100};
-	size_t s_size = SIGN_HEADER_BYTES + messageLength;
-	void *signed_message = heap_allocate(&t, allocator, s_size);
-	if (!Capability{signed_message}.is_valid())
-	{
-		Debug::log("Failed to allocate {} of heap for signed message", s_size);
-		return {nullptr, 0};
-	}
-
-	char *s_context = (char *)signed_message;
-	uint8_t *s_signature = (uint8_t *)s_context + hydro_sign_CONTEXTBYTES;
-	char *s_message = (char *)s_signature + hydro_sign_BYTES;
-
-	strncpy(s_context, context, hydro_sign_CONTEXTBYTES);
-	strncpy(s_message, message, messageLength);
-	
-	// Stuff to look up key from context goes here
-	//
-	uint8_t *key = status_pri_key;
-	
-	crypto_sign(s_signature, message, messageLength, context, status_pri_key);
-	Debug::log("Signature generated");
-	
-	// Create a read only capabilty that is bound to the size of the message
-	Capability<void>s_cap = {signed_message};
-	s_cap.permissions() &= {CHERI::Permission::Load};
-	s_cap.bounds() = s_size;
-
-	return {s_cap, s_size};
-}
- 
-} // namespace CRYPTO 
+} // namespace SIGNATURE

--- a/configuration_broker/sonata/provider/xmake.lua
+++ b/configuration_broker/sonata/provider/xmake.lua
@@ -1,6 +1,10 @@
 -- Copyright Configured Things Ltd and CHERIoT Contributors.
 -- SPDX-License-Identifier: MIT
 
+option("MQTT_Signed")
+    set_default("false")
+    set_description("MQTT messages must be signed")
+
 
 -- Provider Compartment
 compartment("provider")
@@ -21,5 +25,9 @@ compartment("provider")
         target:add('options', "IPv6")
         local IPv6 = get_config("IPv6")
         target:add("defines", "CHERIOT_RTOS_OPTION_IPv6=" .. tostring(IPv6))
+
+        target:add('options', "MQTT_Signed")
+        local MQTT_Signed = get_config("MQTT_Signed")
+        target:add("defines", "MQTT_Signed=" .. tostring(MQTT_Signed))
     end)
 


### PR DESCRIPTION
A previous commit accidentally picked up the signed MQTT message changes being developed as part of DSbD TAP 6 - this PR provides a compiler option to enable signed message support, and sets the default back to unsigned messages.  